### PR TITLE
fix: 修改harmony文件夹下index.ets大小写问题

### DIFF
--- a/harmony/file_viewer/Index.ets
+++ b/harmony/file_viewer/Index.ets
@@ -1,1 +1,0 @@
-export * from './ts';


### PR DESCRIPTION
delete harmony\file_viewer\Index.ets